### PR TITLE
Feature/canonicalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
 
 install:
+  - pip install --upgrade setuptools
   - pip install -e .
   - pip install -e ".[test]"
   - pip install coveralls

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -583,6 +583,8 @@ class IIIFImageClient(object):
 
         # info request
         if path_basename == 'info.json':
+            # NOTE: this is unlikely to happen; more likely, if information is
+            # missing, we will misinterpret the api endpoint or the image id
             if len(path_components) < 1:
                 raise ParseError('Invalid IIIF image information url: %s'
                                     % url)

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -228,10 +228,10 @@ class ImageRegion(object):
             # convert percentages to dimensions based on image size
             self.options.update({
                 'percent': False,
-                'x': (self.options['x']/100) * self.img.image_width,
-                'y': (self.options['y']/100) * self.img.image_height,
-                'width': (self.options['width']/100) * self.img.image_width,
-                'height': (self.options['height']/100) * self.img.image_height
+                'x': int((self.options['x']/100) * self.img.image_width),
+                'y': int((self.options['y']/100) * self.img.image_height),
+                'width': int((self.options['width']/100) * self.img.image_width),
+                'height': int((self.options['height']/100) * self.img.image_height)
             })
             return
 

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -659,7 +659,11 @@ class IIIFImageClient(object):
         # first parse as a url
         parsed_url = urlparse(url)
         # then split the path on slashes
-        path_components = parsed_url.path.split('/')
+        # and remove any empty strings
+        path_components = [path for path in parsed_url.path.split('/') if path]
+        if not path_components:
+            raise ParseError('Invalid IIIF image url: %s'
+                                % url)
         # pop off last portion of the url to determine if this is an info url
         path_basename = path_components.pop()
         opts = {}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = [
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 
-test_requirements = ['pytest', 'pytest-cov']
+test_requirements = ['pytest', 'pytest-cov', 'mock']
 
 setup(
     name='piffle',
@@ -33,7 +33,7 @@ setup(
     url='https://github.com/emory-lits-labs/piffle',
     license='Apache License, Version 2.0',
     packages=find_packages(),
-    install_requires=[],
+    install_requires=['requests', 'cached-properties'],
     setup_requires=['pytest-runner'],
     tests_require=test_requirements,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     url='https://github.com/emory-lits-labs/piffle',
     license='Apache License, Version 2.0',
     packages=find_packages(),
-    install_requires=['requests', 'cached-properties'],
+    install_requires=['requests', 'cached_properties'],
     setup_requires=['pytest-runner'],
     tests_require=test_requirements,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     url='https://github.com/emory-lits-labs/piffle',
     license='Apache License, Version 2.0',
     packages=find_packages(),
-    install_requires=['requests', 'cached_properties'],
+    install_requires=['requests', 'cached-property'],
     setup_requires=['pytest-runner'],
     tests_require=test_requirements,
     extras_require={

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -407,6 +407,13 @@ class TestImageRegion:
             img.region.canonicalize()
             assert unicode(img.region) == '10,1,50,75'
 
+            # percentages should be converted to integers
+            img.region.parse('pct:10,1,50.5,75.3')
+            assert unicode(img.region) == 'pct:10,1,50.5,75.3'
+            img.region.canonicalize()
+            assert unicode(img.region) == '10,1,50,75'
+
+
         # test with square with non-square image size
         tall_img_info = sample_image_info.copy()
         tall_img_info.update({'width': 100, 'height': 150})

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -20,7 +20,7 @@ VALID_URLS = {
 INVALID_URLS = {
     'info': 'http://img1/info.json',
     'simple': 'http://imgserver.co/img1/foobar/default.jpg',
-    'complex': 'http://imgserver.co/img1/2560,2560,256,256/256,/!90/default.jpg',
+    'complex': 'http://imgserver.co/img1/2560,2560,256,/256,/!90/default.jpg',
     'bad_size': '%s/%s/full/a,/0/default.jpg' % (api_endpoint, image_id),
     'bad_region': '%s/%s/200,200/full/0/default.jpg' % (api_endpoint, image_id)
 }
@@ -189,10 +189,15 @@ class TestIIIFImageClient:
         # malformed
         with pytest.raises(iiif.ParseError):
             img = iiif.IIIFImageClient.init_from_url(INVALID_URLS['info'])
+        with pytest.raises(iiif.ParseError):
             iiif.IIIFImageClient.init_from_url(INVALID_URLS['simple'])
+        with pytest.raises(iiif.ParseError):
             iiif.IIIFImageClient.init_from_url(INVALID_URLS['complex'])
+        with pytest.raises(iiif.ParseError):
             iiif.IIIFImageClient.init_from_url(INVALID_URLS['bad_size'])
+        with pytest.raises(iiif.ParseError):
             iiif.IIIFImageClient.init_from_url(INVALID_URLS['bad_region'])
+        with pytest.raises(iiif.ParseError):
             iiif.IIIFImageClient.init_from_url('http://info.json')
 
     def test_as_dicts(self):
@@ -371,6 +376,7 @@ class TestImageRegion:
         # invalid or incomplete region strings
         with pytest.raises(iiif.ParseError):
             region.parse('pct:1,3,')
+        with pytest.raises(iiif.ParseError):
             region.parse('one,two,three,four')
 
     def test_canonicalize(self):
@@ -517,6 +523,7 @@ class TestImageSize:
         # invalid or incomplete size strings
         with pytest.raises(iiif.ParseError):
             size.parse('pct:')
+        with pytest.raises(iiif.ParseError):
             size.parse('one,two')
 
     def test_canonicalize(self):

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -268,7 +268,7 @@ class TestIIIFImageClient:
             # percentage: convert to w,h (= 25,25)
             img.size.parse('pct:25')
             img.rotation.parse('90.0')
-            assert unicode(img.canonicalize()) == \
+            assert six.text_type(img.canonicalize()) == \
                 '%s/%s/full/25,25/90/default.jpg' % (api_endpoint, image_id)
 
 
@@ -391,13 +391,13 @@ class TestImageRegion:
         img = iiif.IIIFImageClient.init_from_url(VALID_URLS['simple'])
         # full to full - trivial canonicalization
         img.region.canonicalize()
-        assert unicode(img.region) == 'full'
+        assert six.text_type(img.region) == 'full'
         # x,y,w,h should be preserved as is
         dimensions = '0,0,200,250'
         img.region.parse(dimensions)
         img.region.canonicalize()
         # round trip, should be the same
-        assert unicode(img.region) == dimensions
+        assert six.text_type(img.region) == dimensions
 
         # test with square image size
         square_img_info = sample_image_info.copy()
@@ -407,18 +407,18 @@ class TestImageRegion:
             # square requested, image is square = full
             img.region.parse('square')
             img.region.canonicalize()
-            assert unicode(img.region) == 'full'
+            assert six.text_type(img.region) == 'full'
 
             # percentages
             img.region.parse('pct:10,1,50,75')
             img.region.canonicalize()
-            assert unicode(img.region) == '10,1,50,75'
+            assert six.text_type(img.region) == '10,1,50,75'
 
             # percentages should be converted to integers
             img.region.parse('pct:10,1,50.5,75.3')
-            assert unicode(img.region) == 'pct:10,1,50.5,75.3'
+            assert six.text_type(img.region) == 'pct:10,1,50.5,75.3'
             img.region.canonicalize()
-            assert unicode(img.region) == '10,1,50,75'
+            assert six.text_type(img.region) == '10,1,50,75'
 
 
         # test with square with non-square image size
@@ -429,7 +429,7 @@ class TestImageRegion:
             # square requested, should convert to x,y,w,h
             img.region.parse('square')
             img.region.canonicalize()
-            assert unicode(img.region) == '0,25,100,100'
+            assert six.text_type(img.region) == '0,25,100,100'
 
         wide_img_info = sample_image_info.copy()
         wide_img_info.update({'width': 200, 'height': 50})
@@ -439,7 +439,7 @@ class TestImageRegion:
             img.region.parse('square')
             img.region.canonicalize()
 
-            assert unicode(img.region) == '75,0,50,50'
+            assert six.text_type(img.region) == '75,0,50,50'
 
 
 class TestImageSize:
@@ -538,7 +538,7 @@ class TestImageSize:
         img = iiif.IIIFImageClient.init_from_url(VALID_URLS['simple'])
         # full to full - trivial canonicalization
         img.size.canonicalize()
-        assert unicode(img.size) == 'full'
+        assert six.text_type(img.size) == 'full'
 
         # test sizes with square image size
         square_img_info = sample_image_info.copy()
@@ -548,17 +548,17 @@ class TestImageSize:
             # requested as ,h - convert to w,
             img.size.parse(',50')
             img.size.canonicalize()
-            assert unicode(img.size) == '50,'
+            assert six.text_type(img.size) == '50,'
 
             # percentage: convert to w,h
             img.size.parse('pct:25')
             img.size.canonicalize()
-            assert unicode(img.size) == '25,25'
+            assert six.text_type(img.size) == '25,25'
 
             # exact
             img.size.parse('!50,50')
             img.size.canonicalize()
-            assert unicode(img.size) == '50,50'
+            assert six.text_type(img.size) == '50,50'
 
         # test sizes with rectangular image size
         rect_img_info = sample_image_info.copy()
@@ -567,7 +567,7 @@ class TestImageSize:
                           new=rect_img_info):
             img.size.parse('!50,50')
             img.size.canonicalize()
-            assert unicode(img.size) == '25,50'
+            assert six.text_type(img.size) == '25,50'
 
 
 class TestImageRotation:
@@ -596,15 +596,15 @@ class TestImageRotation:
 
         # canonicalization
         # - trim any trailing zeros in a decimal value
-        assert unicode(iiif.ImageRotation(degrees=93.0)) == '93'
+        assert six.text_type(iiif.ImageRotation(degrees=93.0)) == '93'
         # - leading zero if less than 1
-        assert unicode(iiif.ImageRotation(degrees=0.05)) == '0.05'
+        assert six.text_type(iiif.ImageRotation(degrees=0.05)) == '0.05'
         # - ! if mirrored, followed by integer if possible
         rotation = iiif.ImageRotation(degrees=95.00, mirrored=True)
-        assert unicode(rotation) == '!95'
+        assert six.text_type(rotation) == '!95'
         # explicitly test canonicalize method, even though it does nothing
         rotation.canonicalize()
-        assert unicode(rotation) == '!95'
+        assert six.text_type(rotation) == '!95'
 
     def test_parse(self):
         rotation = iiif.ImageRotation()


### PR DESCRIPTION
Adding canonicalization logic to the image parameters that need it, based on the spec (as best as I can understand it).

Did some comparisons with what piffle is generating and what Loris returns for canonical headers, think it seems reasonable.  The Loris code has a lot more checking and logic in the canonicalization, but I think that's because it has to do actual image size calculation and error handling that aren't needed in piffle.
