### PR TITLE
Add IIIIF dataclasses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,19 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.270
+    rev: v0.8.3
     hooks:
       - id: ruff
-        args: [ --fix, --exit-non-zero-on-fix ]
+        args: [ --fix]
+
   - repo: https://github.com/psf/black
-    rev: 23.3.0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 24.10.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         # Assumes that your shell's `python` command is linked to python3.6+
         language_version: python
+
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.0
+    rev: 0.30.0
     hooks:
       - id: check-github-workflows

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,66 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.9
+target-version = "py39"
+
+[lint]
+# Enable Pyflakes (`F`), a subset of the pycodestyle (`E`) codes, isort, pyupgrade and pep8 naming.
+select = ["E4", "E7", "E9", "F", "I", "UP"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+extend-safe-fixes = ["UP031"]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# isort
+isort.required-imports = ["from __future__ import annotations"]
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+

--- a/piffle/__init__.py
+++ b/piffle/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 __version__ = "0.6.0"

--- a/piffle/iiif_dataclasses/__init__.py
+++ b/piffle/iiif_dataclasses/__init__.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from .presentation2 import (
+    Annotation2,
+    AnnotationList2,
+    Canvas2,
+    Collection2,
+    Manifest2,
+    Range2,
+    Sequence2,
+)
+from .presentation3 import (
+    AccompanyingCanvas3,
+    Annotation3,
+    AnnotationCollection3,
+    AnnotationPage3,
+    Canvas3,
+    Collection3,
+    GeoreferenceAnnotation3,
+    Manifest3,
+    PlaceholderCanvas3,
+    Range3,
+)
+
+MANIFEST3_CLASSES = {
+    "Collection": Collection3,
+    "Manifest": Manifest3,
+    "Canvas": Canvas3,
+    "PlaceholderCanvas": PlaceholderCanvas3,
+    "AccompanyingCanvas": AccompanyingCanvas3,
+    "AnnotationCollection": AnnotationCollection3,
+    "AnnotationPage": AnnotationPage3,
+    "Annotation": Annotation3,
+    "GeoreferenceAnnotation": GeoreferenceAnnotation3,
+    "Range": Range3,
+}
+
+MANIFEST2_CLASSES = {
+    "sc:Collection": Collection2,
+    "sc:Manifest": Manifest2,
+    "sc:Sequence": Sequence2,
+    "sc:Range": Range2,
+    "sc:Canvas": Canvas2,
+    "sc:AnnotationList": AnnotationList2,
+    "sc:Annotation": Annotation2,
+}

--- a/piffle/iiif_dataclasses/base.py
+++ b/piffle/iiif_dataclasses/base.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass()
+class IIIF3:
+    pass
+
+
+@dataclass()
+class IIIF2:
+    pass

--- a/piffle/iiif_dataclasses/dataclass_utils.py
+++ b/piffle/iiif_dataclasses/dataclass_utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class GeoreferencingError(ValueError):
+    pass
+
+
+def parse_item(item: Any, dataclass: Any, raise_error: bool = True):
+    if item is None:
+        return item
+    elif not isinstance(item, dataclass):
+        try:
+            return dataclass(**item)
+        except GeoreferencingError:
+            raise
+        except ValueError:
+            if raise_error:
+                raise ValueError(f"Item {item} is not an {dataclass}")
+    return item

--- a/piffle/iiif_dataclasses/image2.py
+++ b/piffle/iiif_dataclasses/image2.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .base import IIIF2
+
+## IIIF Image 2
+
+
+@dataclass()
+class IIIFImage2(IIIF2):
+    pass
+
+
+@dataclass()
+class Image2(IIIFImage2):
+    context: Any
+    id: Any
+    protocol: Any
+    width: Any
+    height: Any
+    profile: Any
+    type: Any = None
+    sizes: Any = None
+    tiles: Any = None
+    attribution: Any = None
+    license: Any = None
+    logo: Any = None
+    service: Any = None
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        protocol: Any = None,
+        width: Any = None,
+        height: Any = None,
+        profile: Any = None,
+        type: Any = None,
+        sizes: Any = None,
+        tiles: Any = None,
+        attribution: Any = None,
+        license: Any = None,
+        logo: Any = None,
+        service: Any = None,
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] Image is missing 'context' field.")
+        if id is None:
+            print("[WARNING] Image is missing 'id' field.")
+        if protocol is None:
+            print("[WARNING] Image is missing 'protocol' field.")
+        if width is None:
+            print("[WARNING] Image is missing 'width' field.")
+        if height is None:
+            print("[WARNING] Image is missing 'height' field.")
+        if profile is None:
+            print("[WARNING] Image is missing 'profile' field.")
+
+        self.context = context
+        self.id = id
+        self.protocol = protocol
+        self.width = width
+        self.height = height
+        self.profile = profile
+        self.type = type
+        self.sizes = sizes
+        self.tiles = tiles
+        self.attribution = attribution
+        self.license = license
+        self.logo = logo
+        self.service = service
+        self.other_metadata = kwargs

--- a/piffle/iiif_dataclasses/image3.py
+++ b/piffle/iiif_dataclasses/image3.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .base import IIIF3
+
+## IIIF Image 3
+
+
+@dataclass()
+class IIIFImage3(IIIF3):
+    pass
+
+
+@dataclass()
+class Image3(IIIFImage3):
+    context: Any
+    id: Any
+    type: Any
+    protocol: Any
+    profile: Any
+    width: Any
+    height: Any
+    maxWidth: Any = None
+    maxHeight: Any = None
+    maxArea: Any = None
+    sizes: Any = None
+    tiles: Any = None
+    preferredFormats: Any = None
+    extraQualities: Any = None
+    extraFormats: Any = None
+    extraFeatures: Any = None
+    rights: Any = None
+    label: Any = None
+    format: Any = None
+    seeAlso: Any = None
+    partOf: Any = None
+    service: Any = None
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        protocol: Any = None,
+        profile: Any = None,
+        width: Any = None,
+        height: Any = None,
+        maxWidth: Any = None,
+        maxHeight: Any = None,
+        maxArea: Any = None,
+        sizes: Any = None,
+        tiles: Any = None,
+        preferredFormats: Any = None,
+        extraQualities: Any = None,
+        extraFormats: Any = None,
+        extraFeatures: Any = None,
+        rights: Any = None,
+        label: Any = None,
+        format: Any = None,
+        seeAlso: Any = None,
+        partOf: Any = None,
+        service: Any = None,
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] Image is missing 'context' field.")
+        if id is None:
+            print("[WARNING] Image is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Image is missing 'type' field.")
+        if protocol is None:
+            print("[WARNING] Image is missing 'protocol' field.")
+        if profile is None:
+            print("[WARNING] Image is missing 'profile' field.")
+        if width is None:
+            print("[WARNING] Image is missing 'width' field.")
+        if height is None:
+            print("[WARNING] Image is missing 'height' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.protocol = protocol
+        self.profile = profile
+        self.width = width
+        self.height = height
+        self.maxWidth = maxWidth
+        self.maxHeight = maxHeight
+        self.maxArea = maxArea
+        self.sizes = sizes
+        self.tiles = tiles
+        self.preferredFormats = preferredFormats
+        self.extraQualities = extraQualities
+        self.extraFormats = extraFormats
+        self.extraFeatures = extraFeatures
+        self.rights = rights
+        self.label = label
+        self.format = format
+        self.seeAlso = seeAlso
+        self.partOf = partOf
+        self.service = service
+        self.other_metadata = kwargs

--- a/piffle/iiif_dataclasses/presentation2.py
+++ b/piffle/iiif_dataclasses/presentation2.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .base import IIIF2
+from .dataclass_utils import parse_item
+
+## IIIF Presentation 2
+
+
+@dataclass()
+class IIIFPresentation2(IIIF2):
+    pass
+
+
+@dataclass()
+class Annotation2(IIIFPresentation2):
+    context: Any
+    id: Any
+    type: Any
+    resource: Any = None
+    on: Any = None
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        resource: Any = None,
+        on: Any = None,
+        **kwargs,
+    ):
+        if id is None:
+            print("[WARNING] Annotation is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Annotation is missing 'type' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.resource = resource
+        self.on = on
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        return [self]
+
+    def get_image_url(self):
+        return self.resource["service"]["id"]
+
+
+@dataclass()
+class AnnotationList2(IIIFPresentation2):
+    context: Any
+    id: Any
+    type: Any
+    resources: list[Annotation2] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        resources: list[Annotation2 | Any] = [],
+        **kwargs,
+    ):
+        if id is None:
+            print("[WARNING] AnnotationList is missing 'id' field.")
+        if type is None:
+            print("[WARNING] AnnotationList is missing 'type' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.resources = [parse_item(resource, Annotation2) for resource in resources]
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        annotations = []
+        for resource in self.resources:
+            annotations += resource.collect_annotations()
+        return annotations
+
+
+@dataclass()
+class Canvas2(IIIFPresentation2):
+    context: Any
+    id: Any
+    type: Any
+    images: list[Annotation2] = field(default_factory=list)
+    otherContent: list[AnnotationList2] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        images: list[Annotation2 | Any] = [],
+        otherContent: list[AnnotationList2 | Any] = [],
+        **kwargs,
+    ):
+        if id is None:
+            print("[WARNING] Canvas is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Canvas is missing 'type' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.images = [parse_item(image, Annotation2) for image in images]
+        self.otherContent = [
+            parse_item(content, AnnotationList2) for content in otherContent
+        ]
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        # TODO: Not sure which annotations to collect here??
+        annotations = []
+        for image in self.images:
+            annotations += image.collect_annotations()
+        for content in self.otherContent:
+            annotations += content.collect_annotations()
+        return annotations
+
+
+@dataclass()
+class Range2(IIIFPresentation2):
+    context: Any
+    id: Any
+    type: Any
+    ranges: list[Any] = field(default_factory=list)  # a list of ranges, they self loop
+    canvases: list[Canvas2] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        ranges: list[Any] = [],
+        canvases: list[Canvas2 | Any] = [],
+        **kwargs,
+    ):
+
+        if context is None:
+            print("[WARNING] Range is missing 'context' field.")
+        if id is None:
+            print("[WARNING] Range is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Range is missing 'type' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.ranges = ranges
+        self.canvases = [parse_item(canvas, Canvas2) for canvas in canvases]
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        annotations = []
+        for canvas in self.canvases:
+            annotations += canvas.collect_annotations()
+        return annotations
+
+
+@dataclass()
+class Sequence2(IIIFPresentation2):
+    context: Any
+    id: Any
+    type: Any
+    canvases: list[Canvas2] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        canvases: list[Canvas2 | Any] = [],
+        **kwargs,
+    ):
+        if id is None:
+            print("[WARNING] Sequence is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Sequence is missing 'type' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.canvases = [parse_item(canvas, Canvas2) for canvas in canvases]
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        annotations = []
+        for canvas in self.canvases:
+            annotations += canvas.collect_annotations()
+        return annotations
+
+
+@dataclass()
+class Manifest2(IIIFPresentation2):
+    context: Any
+    id: Any
+    type: Any
+    startCanvas: Any = None
+    sequences: list[Sequence2] = field(default_factory=list)
+    structures: list[Range2] = field(default_factory=list)
+    metadata: list[Any] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        startCanvas: Any = None,
+        sequences: list[Sequence2 | Any] = [],
+        structures: list[Range2 | Any] = [],
+        metadata: list[Any] = [],
+        **kwargs,
+    ):
+        if id is None:
+            print("[WARNING] Manifest is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Manifest is missing 'type' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.startCanvas = startCanvas
+        self.sequences = [parse_item(sequence, Sequence2) for sequence in sequences]
+        self.structures = [parse_item(structure, Range2) for structure in structures]
+        self.metadata = metadata
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        # TODO: Not sure which annotations to collect here??
+        annotations = []
+        for sequence in self.sequences:
+            annotations += sequence.collect_annotations()
+        for structure in self.structures:
+            annotations += structure.collect_annotations()
+        return annotations
+
+
+@dataclass()
+class Collection2(IIIFPresentation2):
+    context: Any
+    id: Any
+    type: Any
+    collections: list[Any] = field(
+        default_factory=list
+    )  # a list of collections, they self loop
+    manifests: list[Manifest2] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        collections: list[Any] = [],
+        manifests: list[Manifest2 | Any] = [],
+        **kwargs,
+    ):
+        if id is None:
+            print("[WARNING] Collection is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Collection is missing 'type' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.collections = collections
+        self.manifests = [parse_item(manifest, Manifest2) for manifest in manifests]
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        annotations = []
+        for manifest in self.manifests:
+            annotations += manifest.collect_annotations()
+        return annotations

--- a/piffle/iiif_dataclasses/presentation3.py
+++ b/piffle/iiif_dataclasses/presentation3.py
@@ -1,0 +1,678 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .base import IIIF3
+from .dataclass_utils import GeoreferencingError, parse_item
+
+## IIIF Presentation 3
+
+
+@dataclass()
+class IIIFPresentation3(IIIF3):
+    @staticmethod
+    def parse_annotation(item: Any):
+        try:
+            return parse_item(item, GeoreferenceAnnotation3)
+        except GeoreferencingError:
+            return parse_item(item, Annotation3)
+
+
+@dataclass()
+class Annotation3(IIIFPresentation3):
+    context: Any
+    id: Any
+    type: Any
+    target: Any
+    label: Any = None
+    service: Any = None
+    rendering: Any = None
+    thumbnail: list[Any] = field(default_factory=list)
+    motivation: Any = None
+    body: Any = None
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        target: Any = None,
+        label: Any = None,
+        service: Any = None,
+        rendering: Any = None,
+        thumbnail: list[Any] = [],
+        motivation: Any = None,
+        body: Any = None,
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] Annotation is missing 'context' field.")
+        if id is None:
+            print("[WARNING] Annotation is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Annotation is missing 'type' field.")
+        if target is None:
+            print("[WARNING] Annotation is missing 'target' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.target = target
+        self.label = label
+        self.service = service
+        self.rendering = rendering
+        self.thumbnail = thumbnail
+        self.motivation = motivation
+        self.body = body
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        return [self]
+
+    def get_image_url(self):
+        return self.target["source"]["id"]
+
+
+@dataclass()
+class GeoreferenceAnnotation3(Annotation3):
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        target: Any = None,
+        label: Any = None,
+        service: Any = None,
+        rendering: Any = None,
+        thumbnail: list[Any] = [],
+        motivation: Any = None,
+        body: Any = None,
+        **kwargs,
+    ):
+        if motivation != "georeferencing":
+            raise GeoreferencingError("Motivation must be 'georeferencing'")
+
+        super().__init__(
+            context=context,
+            id=id,
+            type=type,
+            target=target,
+            label=label,
+            service=service,
+            rendering=rendering,
+            thumbnail=thumbnail,
+            motivation=motivation,
+            body=body,
+            **kwargs,
+        )
+
+
+@dataclass()
+class AnnotationCollection3(IIIFPresentation3):
+    context: Any
+    id: Any
+    type: Any
+    label: Any = None
+    rendering: Any = None
+    partOf: Any = None
+    next: Any = None
+    first: Any = None
+    last: Any = None
+    service: Any = None
+    total: Any = None
+    thumbnail: list[Any] = field(default_factory=list)
+    items: list[Annotation3] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        label: Any = None,
+        rendering: Any = None,
+        partOf: Any = None,
+        next: Any = None,
+        first: Any = None,
+        last: Any = None,
+        service: Any = None,
+        total: Any = None,
+        thumbnail: list[Any] = [],
+        items: list[Annotation3 | Any] = [],
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] AnnotationCollection is missing 'context' field.")
+        if id is None:
+            print("[WARNING] AnnotationCollection is missing 'id' field.")
+        if type is None:
+            print("[WARNING] AnnotationCollection is missing 'type' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.label = label
+        self.rendering = rendering
+        self.partOf = partOf
+        self.next = next
+        self.first = first
+        self.last = last
+        self.service = service
+        self.total = total
+        self.thumbnail = thumbnail
+        self.items = [self.parse_annotation(item) for item in items]
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        return self.items
+
+
+@dataclass()
+class AnnotationPage3(IIIFPresentation3):
+    context: Any
+    id: Any
+    type: Any
+    items: list[Annotation3]
+    label: Any = None
+    rendering: Any = None
+    service: Any = None
+    thumbnail: list[Any] = field(default_factory=list)
+    partOf: list[AnnotationCollection3] = field(default_factory=list)
+    next: Any = None
+    prev: Any = None
+    first: Any = None
+    last: Any = None
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        items: list[Annotation3 | Any] = [],
+        label: Any = None,
+        rendering: Any = None,
+        service: Any = None,
+        thumbnail: list[Any] = [],
+        partOf: list[AnnotationCollection3 | Any] = [],
+        next: Any = None,
+        prev: Any = None,
+        first: Any = None,
+        last: Any = None,
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] AnnotationPage is missing 'context' field.")
+        if id is None:
+            print("[WARNING] AnnotationPage is missing 'id' field.")
+        if type is None:
+            print("[WARNING] AnnotationPage is missing 'type' field.")
+        if items is None:
+            print("[WARNING] AnnotationPage is missing 'items' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.items = [
+            self.parse_annotation(item) for item in items
+        ]  # list of annotations, see Annotation class
+        self.label = label
+        self.rendering = rendering
+        self.service = service
+        self.thumbnail = thumbnail
+        self.partOf = [
+            parse_item(part, AnnotationCollection3) for part in partOf
+        ]  # list of annotation collections, see AnnotationCollection class
+        self.next = next
+        self.prev = prev
+        self.first = first
+        self.last = last
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        return self.items
+
+
+@dataclass()
+class PlaceholderCanvas3(IIIFPresentation3):
+    context: Any
+    id: Any
+    type: Any
+    items: list[
+        AnnotationPage3
+    ]  # this is annotations with "painting" motivation (i.e. located on the canvas)
+    label: Any = None
+    height: Any = None
+    width: Any = None
+    duration: Any = None
+    metadata: Any = None
+    summary: Any = None
+    requiredStatement: Any = None
+    rendering: Any = None
+    rights: Any = None
+    navDate: Any = None
+    navPlace: Any = None
+    provider: Any = None
+    seeAlso: Any = None
+    service: Any = None
+    thumbnail: list[Any] = field(default_factory=list)
+    homepage: Any = None
+    behavior: Any = None
+    partOf: Any = None
+    annotations: list[AnnotationPage3 | Any] = field(
+        default_factory=list
+    )  # this is more like metadata or supplementary info
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        items: list[AnnotationPage3 | Any] = [],
+        label: Any = None,
+        height: Any = None,
+        width: Any = None,
+        duration: Any = None,
+        metadata: Any = None,
+        summary: Any = None,
+        requiredStatement: Any = None,
+        rendering: Any = None,
+        rights: Any = None,
+        navDate: Any = None,
+        navPlace: Any = None,
+        provider: Any = None,
+        seeAlso: Any = None,
+        service: Any = None,
+        thumbnail: list[Any] = [],
+        homepage: Any = None,
+        behavior: Any = None,
+        partOf: Any = None,
+        annotations: list[AnnotationPage3 | Any] = [],
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] PlaceholderCanvas is missing 'context' field.")
+        if id is None:
+            print("[WARNING] PlaceholderCanvas is missing 'id' field.")
+        if type is None:
+            print("[WARNING] PlaceholderCanvas is missing 'type' field.")
+        if items is None:
+            print("[WARNING] PlaceholderCanvas is missing 'items' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.items = [
+            parse_item(item, AnnotationPage3) for item in items
+        ]  # list of annotation pages, see AnnotationPage class
+        self.label = label
+        self.height = height
+        self.width = width
+        self.duration = duration
+        self.metadata = metadata
+        self.summary = summary
+        self.requiredStatement = requiredStatement
+        self.rendering = rendering
+        self.rights = rights
+        self.navDate = navDate
+        self.navPlace = navPlace
+        self.provider = provider
+        self.seeAlso = seeAlso
+        self.service = service
+        self.thumbnail = thumbnail
+        self.homepage = homepage
+        self.behavior = behavior
+        self.partOf = partOf
+        self.annotations = [
+            parse_item(annotation, AnnotationPage3, raise_error=False)
+            for annotation in annotations
+        ]  # more like supplementary info, don't use this one
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        annotations = []
+        for item in self.items:
+            annotations += item.collect_annotations()
+        return annotations
+
+
+@dataclass()
+class AccompanyingCanvas3(PlaceholderCanvas3):
+    pass
+
+
+@dataclass()
+class Canvas3(PlaceholderCanvas3):
+    placeholderCanvas: PlaceholderCanvas3 = None
+    accompanyingCanvas: AccompanyingCanvas3 = None
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        items: list[
+            AnnotationPage3 | Any
+        ] = [],  # this is annotations with "painting" motivation (i.e. located on the canvas)
+        label: Any = None,
+        height: Any = None,
+        width: Any = None,
+        duration: Any = None,
+        metadata: Any = None,
+        summary: Any = None,
+        requiredStatement: Any = None,
+        rendering: Any = None,
+        rights: Any = None,
+        navDate: Any = None,
+        navPlace: Any = None,
+        provider: Any = None,
+        seeAlso: Any = None,
+        service: Any = None,
+        thumbnail: list[Any] = [],
+        homepage: Any = None,
+        behavior: Any = None,
+        partOf: Any = None,
+        annotations: list[
+            AnnotationPage3 | Any
+        ] = [],  # this is more like metadata or supplementary info
+        placeholderCanvas: PlaceholderCanvas3 | Any = None,
+        accompanyingCanvas: AccompanyingCanvas3 | Any = None,
+        **kwargs,
+    ):
+        super().__init__(
+            context=context,
+            id=id,
+            type=type,
+            items=items,
+            label=label,
+            height=height,
+            width=width,
+            duration=duration,
+            metadata=metadata,
+            summary=summary,
+            requiredStatement=requiredStatement,
+            rendering=rendering,
+            rights=rights,
+            navDate=navDate,
+            navPlace=navPlace,
+            provider=provider,
+            seeAlso=seeAlso,
+            service=service,
+            thumbnail=thumbnail,
+            homepage=homepage,
+            behavior=behavior,
+            partOf=partOf,
+            annotations=annotations,
+            **kwargs,
+        )
+        self.placeholderCanvas = parse_item(placeholderCanvas, PlaceholderCanvas3)
+        self.accompanyingCanvas = parse_item(accompanyingCanvas, AccompanyingCanvas3)
+
+
+@dataclass()
+class Collection3(IIIFPresentation3):
+    context: Any
+    id: Any
+    type: Any
+    label: Any
+    metadata: Any = None
+    summary: Any = None
+    requiredStatement: Any = None
+    rendering: Any = None
+    rights: Any = None
+    navDate: Any = None
+    navPlace: Any = None
+    provider: Any = None
+    seeAlso: Any = None
+    services: Any = None
+    service: Any = None
+    placeholderCanvas: PlaceholderCanvas3 = None
+    accompanyingCanvas: AccompanyingCanvas3 = None
+    thumbnail: list[Any] = field(default_factory=list)
+    homepage: Any = None
+    behavior: Any = None
+    partOf: Any = None
+    items: list[Any] = field(default_factory=list)
+    annotations: list[AnnotationPage3 | Any] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        label: Any = None,
+        metadata: Any = None,
+        summary: Any = None,
+        requiredStatement: Any = None,
+        rendering: Any = None,
+        rights: Any = None,
+        navDate: Any = None,
+        navPlace: Any = None,
+        provider: Any = None,
+        seeAlso: Any = None,
+        services: Any = None,
+        service: Any = None,
+        placeholderCanvas: PlaceholderCanvas3 | Any = None,
+        accompanyingCanvas: AccompanyingCanvas3 | Any = None,
+        thumbnail: list[Any] = [],
+        homepage: Any = None,
+        behavior: Any = None,
+        partOf: Any = None,
+        items: list[Any] = [],
+        annotations: list[AnnotationPage3 | Any] = [],
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] Collection is missing 'context' field.")
+        if id is None:
+            print("[WARNING] Collection is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Collection is missing 'type' field.")
+        if label is None:
+            print("[WARNING] Collection is missing 'label' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.label = label
+        self.metadata = metadata
+        self.summary = summary
+        self.requiredStatement = requiredStatement
+        self.rendering = rendering
+        self.rights = rights
+        self.navDate = navDate
+        self.navPlace = navPlace
+        self.provider = provider
+        self.seeAlso = seeAlso
+        self.services = services
+        self.service = service
+        self.placeholderCanvas = parse_item(placeholderCanvas, PlaceholderCanvas3)
+        self.accompanyingCanvas = parse_item(accompanyingCanvas, AccompanyingCanvas3)
+        self.thumbnail = thumbnail
+        self.homepage = homepage
+        self.behavior = behavior
+        self.partOf = partOf
+        self.items = items
+        self.annotations = [
+            parse_item(annotation, AnnotationPage3, raise_error=False)
+            for annotation in annotations
+        ]
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        annotations = []
+        for item in self.items:
+            annotations += item.collect_annotations()
+        return annotations
+
+
+@dataclass()
+class Range3(IIIFPresentation3):
+    context: Any
+    id: Any
+    type: Any
+    items: list[Any]
+    label: Any = None
+    rendering: Any = None
+    supplementary: AnnotationCollection3 = None
+    service: Any = None
+    placeholderCanvas: PlaceholderCanvas3 = None
+    accompanyingCanvas: AccompanyingCanvas3 = None
+    annotations: list[AnnotationPage3 | Any] = field(default_factory=list)
+    thumbnail: list[Any] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        items: list[Any] = [],
+        label: Any = None,
+        rendering: Any = None,
+        supplementary: AnnotationCollection3 | Any = None,
+        service: Any = None,
+        placeholderCanvas: PlaceholderCanvas3 | Any = None,
+        accompanyingCanvas: AccompanyingCanvas3 | Any = None,
+        annotations: list[AnnotationPage3 | Any] = [],
+        thumbnail: list[Any] = [],
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] Range is missing 'context' field.")
+        if id is None:
+            print("[WARNING] Range is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Range is missing 'type' field.")
+        if items is None:
+            print("[WARNING] Range is missing 'items' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.items = items
+        self.label = label
+        self.rendering = rendering
+        self.supplementary = parse_item(supplementary, AnnotationCollection3)
+        self.service = service
+        self.placeholderCanvas = parse_item(placeholderCanvas, PlaceholderCanvas3)
+        self.accompanyingCanvas = parse_item(accompanyingCanvas, AccompanyingCanvas3)
+        self.annotations = [
+            parse_item(annotation, AnnotationPage3, raise_error=False)
+            for annotation in annotations
+        ]
+        self.thumbnail = thumbnail
+        self.other_metadata = kwargs
+
+
+@dataclass()
+class Manifest3(IIIFPresentation3):
+    context: Any
+    id: Any
+    type: Any
+    label: Any
+    metadata: Any = None
+    summary: Any = None
+    requiredStatement: Any = None
+    rendering: Any = None
+    service: Any = None
+    services: Any = None
+    viewingDirection: Any = None
+    placeholderCanvas: PlaceholderCanvas3 = None
+    accompanyingCanvas: AccompanyingCanvas3 = None
+    rights: Any = None
+    start: Any = None
+    navDate: Any = None
+    navPlace: Any = None
+    provider: Any = None
+    seeAlso: Any = None
+    thumbnail: list[Any] = field(default_factory=list)
+    homepage: Any = None
+    behavior: Any = None
+    partOf: Any = None
+    items: list[Canvas3] = field(default_factory=list)
+    structures: list[Range3] = field(default_factory=list)
+    annotations: list[AnnotationPage3 | Any] = field(default_factory=list)
+    other_metadata: dict = field(default_factory=dict)
+
+    def __init__(
+        self,
+        context: Any = None,
+        id: Any = None,
+        type: Any = None,
+        label: Any = None,
+        metadata: Any = None,
+        summary: Any = None,
+        requiredStatement: Any = None,
+        rendering: Any = None,
+        service: Any = None,
+        services: Any = None,
+        viewingDirection: Any = None,
+        placeholderCanvas: PlaceholderCanvas3 | Any = None,
+        accompanyingCanvas: AccompanyingCanvas3 | Any = None,
+        rights: Any = None,
+        start: Any = None,
+        navDate: Any = None,
+        navPlace: Any = None,
+        provider: Any = None,
+        seeAlso: Any = None,
+        thumbnail: list[Any] = [],
+        homepage: Any = None,
+        behavior: Any = None,
+        partOf: Any = None,
+        items: list[Canvas3 | Any] = [],
+        structures: list[Range3 | Any] = [],
+        annotations: list[AnnotationPage3 | Any] = [],
+        **kwargs,
+    ):
+        if context is None:
+            print("[WARNING] Manifest is missing 'context' field.")
+        if id is None:
+            print("[WARNING] Manifest is missing 'id' field.")
+        if type is None:
+            print("[WARNING] Manifest is missing 'type' field.")
+        if label is None:
+            print("[WARNING] Manifest is missing 'label' field.")
+
+        self.context = context
+        self.id = id
+        self.type = type
+        self.label = label
+        self.metadata = metadata
+        self.summary = summary
+        self.requiredStatement = requiredStatement
+        self.rendering = rendering
+        self.service = service
+        self.services = services
+        self.viewingDirection = viewingDirection
+        self.placeholderCanvas = parse_item(placeholderCanvas, PlaceholderCanvas3)
+        self.accompanyingCanvas = parse_item(accompanyingCanvas, AccompanyingCanvas3)
+        self.rights = rights
+        self.start = start
+        self.navDate = navDate
+        self.navPlace = navPlace
+        self.provider = provider
+        self.seeAlso = seeAlso
+        self.thumbnail = thumbnail
+        self.homepage = homepage
+        self.behavior = behavior
+        self.partOf = partOf
+        self.items = [
+            parse_item(item, Canvas3) for item in items
+        ]  # list of canvases, see Canvas class
+        self.structures = [parse_item(structure, Range3) for structure in structures]
+        self.annotations = [
+            parse_item(annotation, AnnotationPage3, raise_error=False)
+            for annotation in annotations
+        ]
+        self.other_metadata = kwargs
+
+    def collect_annotations(self):
+        annotations = []
+        for item in self.items:
+            annotations += item.collect_annotations()
+        return annotations

--- a/piffle/load_iiif.py
+++ b/piffle/load_iiif.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from .iiif_dataclasses import MANIFEST2_CLASSES, MANIFEST3_CLASSES
+from .iiif_dataclasses.image2 import Image2
+from .iiif_dataclasses.image3 import Image3
+from .utils import get_manifest
+
+
+class UnknownClassError(ValueError):
+    pass
+
+
+def load_iiif_presentation(url: str, presentation_version: int | float | str):
+    manifest = get_manifest(url)
+
+    if presentation_version in [3, 3.0, "3", "3.0"]:
+        manifest_class = MANIFEST3_CLASSES.get(manifest["type"], None)
+    elif presentation_version in [2, 2.0, 2.1, "2", "2.0", "2.1"]:
+        manifest_class = MANIFEST2_CLASSES.get(manifest["type"], None)
+    else:
+        raise ValueError(f"Presentation version {presentation_version} not supported.")
+
+    if manifest_class is None:
+        raise UnknownClassError(
+            f"Class {manifest['type']} not found in IIIF Presentation {presentation_version}"
+        )
+
+    return manifest_class(**manifest)
+
+
+def load_iiif_image(url: str, image_version: int | float | str):
+    manifest = get_manifest(url)
+
+    if image_version in [3, 3.0, "3", "3.0"]:
+        return Image3(**manifest)
+    elif image_version in [2, 2.0, 2.1, "2", "2.0", "2.1"]:
+        return Image2(**manifest)
+    else:
+        raise ValueError(f"Presentation version {image_version} not supported.")

--- a/piffle/presentation.py
+++ b/piffle/presentation.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import json
 import os.path
 import urllib
 
 import addict
-
 import requests
 
 
@@ -19,7 +20,7 @@ class AtDict(addict.Dict):
     def _key(self, key):
         # convert key to @key if in the list of fields that requires it
         if key in self.at_fields:
-            key = "@%s" % key
+            key = f"@{key}"
         return key
 
     def __missing__(self, key):
@@ -96,13 +97,12 @@ class IIIFPresentation(AtDict):
                 # if json fails, two possibilities:
                 # - we didn't actually get json (e.g. redirect for auth)
                 if "application/json" not in response.headers["content-type"]:
-                    raise IIIFException("No JSON found at %s" % uri)
+                    raise IIIFException(f"No JSON found at {uri}")
                 # - there is something wrong with the json
-                raise IIIFException("Error parsing JSON for %s: %s" % (uri, err))
+                raise IIIFException(f"Error parsing JSON for {uri}: {err}")
 
         raise IIIFException(
-            "Error retrieving manifest at %s: %s %s"
-            % (uri, response.status_code, response.reason)
+            f"Error retrieving manifest at {uri}: {response.status_code} {response.reason}"
         )
 
     @classmethod
@@ -118,7 +118,7 @@ class IIIFPresentation(AtDict):
         elif cls.is_url(path):
             return cls.from_url(path)
         else:
-            raise IIIFException("File not found: %s" % path)
+            raise IIIFException(f"File not found: {path}")
 
     @classmethod
     def short_id(cls, uri):

--- a/piffle/utils.py
+++ b/piffle/utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+
+import requests
+
+
+def format_manifest(d: dict):
+    formatted = {}
+    for k, v in d.items():
+        if k.startswith("@"):
+            k = k.replace("@", "")  # for now, just remove the @
+            formatted.setdefault("_at_fields", []).append(k)
+        if k.startswith("_"):
+            k = k.replace("_", "")  # for now, just remove the _
+            formatted.setdefault("_underscore_fields", []).append(k)
+        formatted[k] = v
+    return formatted
+
+
+def get_manifest(url: str):
+    response = requests.get(url)
+    response.raise_for_status()
+    return json.loads(response.text, object_hook=format_manifest)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,30 +1,31 @@
+from __future__ import annotations
+
 from unittest.mock import patch
+
 import pytest
 import requests
 
 from piffle import image
-
 
 api_endpoint = "http://imgserver.co"
 image_id = "img1"
 
 # test iiif image urls
 VALID_URLS = {
-    "info": "%s/%s/info.json" % (api_endpoint, image_id),
+    "info": f"{api_endpoint}/{image_id}/info.json",
     # longer api endpoint path
-    "info-loris": "%s/loris/%s/info.json" % (api_endpoint, image_id),
-    "simple": "%s/%s/full/full/0/default.jpg" % (api_endpoint, image_id),
-    "complex": "%s/%s/2560,2560,256,256/256,/!90/default.jpg"
-    % (api_endpoint, image_id),
-    "exact": "%s/%s/full/!256,256/0/default.jpg" % (api_endpoint, image_id),
+    "info-loris": f"{api_endpoint}/loris/{image_id}/info.json",
+    "simple": f"{api_endpoint}/{image_id}/full/full/0/default.jpg",
+    "complex": f"{api_endpoint}/{image_id}/2560,2560,256,256/256,/!90/default.jpg",
+    "exact": f"{api_endpoint}/{image_id}/full/!256,256/0/default.jpg",
 }
 
 INVALID_URLS = {
     "info": "http://img1/info.json",
     "simple": "http://imgserver.co/img1/foobar/default.jpg",
     "complex": "http://imgserver.co/img1/2560,2560,256,/256,/!90/default.jpg",
-    "bad_size": "%s/%s/full/a,/0/default.jpg" % (api_endpoint, image_id),
-    "bad_region": "%s/%s/200,200/full/0/default.jpg" % (api_endpoint, image_id),
+    "bad_size": f"{api_endpoint}/{image_id}/full/a,/0/default.jpg",
+    "bad_region": f"{api_endpoint}/{image_id}/200,200/full/0/default.jpg",
 }
 
 sample_image_info = {
@@ -43,9 +44,9 @@ class TestIIIFImageClient:
     def test_defaults(self):
         img = get_test_imgclient()
         # default image url
-        assert "%s/%s/full/full/0/default.jpg" % (api_endpoint, image_id) == str(img)
+        assert f"{api_endpoint}/{image_id}/full/full/0/default.jpg" == str(img)
         # info url
-        assert "%s/%s/info.json" % (api_endpoint, image_id) == str(img.info())
+        assert f"{api_endpoint}/{image_id}/info.json" == str(img.info())
 
     def test_outputs(self):
         img = get_test_imgclient()
@@ -85,52 +86,40 @@ class TestIIIFImageClient:
         img = get_test_imgclient()
         width, height, percent = 100, 150, 50
         # width only
-        assert "%s/%s/full/%s,/0/default.jpg" % (api_endpoint, image_id, width) == str(
+        assert f"{api_endpoint}/{image_id}/full/{width},/0/default.jpg" == str(
             img.size(width=width)
         )
 
         # height only
-        assert "%s/%s/full/,%s/0/default.jpg" % (api_endpoint, image_id, height) == str(
+        assert f"{api_endpoint}/{image_id}/full/,{height}/0/default.jpg" == str(
             img.size(height=height)
         )
         # width and height
-        assert "%s/%s/full/%s,%s/0/default.jpg" % (
-            api_endpoint,
-            image_id,
-            width,
-            height,
-        ) == str(img.size(width=width, height=height))
+        assert f"{api_endpoint}/{image_id}/full/{width},{height}/0/default.jpg" == str(
+            img.size(width=width, height=height)
+        )
         # exact width and height
-        assert "%s/%s/full/!%s,%s/0/default.jpg" % (
-            api_endpoint,
-            image_id,
-            width,
-            height,
-        ) == str(img.size(width=width, height=height, exact=True))
+        assert f"{api_endpoint}/{image_id}/full/!{width},{height}/0/default.jpg" == str(
+            img.size(width=width, height=height, exact=True)
+        )
         # percent
-        assert "%s/%s/full/pct:%s/0/default.jpg" % (
-            api_endpoint,
-            image_id,
-            percent,
-        ) == str(img.size(percent=percent))
+        assert f"{api_endpoint}/{image_id}/full/pct:{percent}/0/default.jpg" == str(
+            img.size(percent=percent)
+        )
 
     def test_region(self):
         # region options passed through to region object and output
         img = get_test_imgclient()
         x, y, width, height = 5, 10, 100, 150
-        assert "%s/%s/%s,%s,%s,%s/full/0/default.jpg" % (
-            api_endpoint,
-            image_id,
-            x,
-            y,
-            width,
-            height,
-        ) == str(img.region(x=x, y=y, width=width, height=height))
+        assert (
+            f"{api_endpoint}/{image_id}/{x},{y},{width},{height}/full/0/default.jpg"
+            == str(img.region(x=x, y=y, width=width, height=height))
+        )
 
     def test_rotation(self):
         # rotation options passed through to region object and output
         img = get_test_imgclient()
-        assert "%s/%s/full/full/90/default.jpg" % (api_endpoint, image_id) == str(
+        assert f"{api_endpoint}/{image_id}/full/full/90/default.jpg" == str(
             img.rotation(degrees=90)
         )
         with pytest.raises(image.IIIFImageClientException):
@@ -152,59 +141,38 @@ class TestIIIFImageClient:
         img = get_test_imgclient()
         width = 100
         fmt = "png"
-        assert "%s/%s/full/%s,/0/default.%s" % (
-            api_endpoint,
-            image_id,
-            width,
-            fmt,
-        ) == str(img.size(width=width).format(fmt))
+        assert f"{api_endpoint}/{image_id}/full/{width},/0/default.{fmt}" == str(
+            img.size(width=width).format(fmt)
+        )
 
         img = get_test_imgclient()
         x, y, width, height = 5, 10, 100, 150
-        assert "%s/%s/%s,%s,%s,%s/full/0/default.%s" % (
-            api_endpoint,
-            image_id,
-            x,
-            y,
-            width,
-            height,
-            fmt,
-        ) == str(img.region(x=x, y=y, width=width, height=height).format(fmt))
+        assert (
+            f"{api_endpoint}/{image_id}/{x},{y},{width},{height}/full/0/default.{fmt}"
+            == str(img.region(x=x, y=y, width=width, height=height).format(fmt))
+        )
 
-        assert "%s/%s/%s,%s,%s,%s/%s,/0/default.%s" % (
-            api_endpoint,
-            image_id,
-            x,
-            y,
-            width,
-            height,
-            width,
-            fmt,
-        ) == str(
-            img.size(width=width)
-            .region(x=x, y=y, width=width, height=height)
-            .format(fmt)
+        assert (
+            f"{api_endpoint}/{image_id}/{x},{y},{width},{height}/{width},/0/default.{fmt}"
+            == str(
+                img.size(width=width)
+                .region(x=x, y=y, width=width, height=height)
+                .format(fmt)
+            )
         )
         rotation = 90
-        assert "%s/%s/%s,%s,%s,%s/%s,/%s/default.%s" % (
-            api_endpoint,
-            image_id,
-            x,
-            y,
-            width,
-            height,
-            width,
-            rotation,
-            fmt,
-        ) == str(
-            img.size(width=width)
-            .region(x=x, y=y, width=width, height=height)
-            .rotation(degrees=90)
-            .format(fmt)
+        assert (
+            f"{api_endpoint}/{image_id}/{x},{y},{width},{height}/{width},/{rotation}/default.{fmt}"
+            == str(
+                img.size(width=width)
+                .region(x=x, y=y, width=width, height=height)
+                .rotation(degrees=90)
+                .format(fmt)
+            )
         )
 
         # original image object should be unchanged, and still show defaults
-        assert "%s/%s/full/full/0/default.jpg" % (api_endpoint, image_id) == str(img)
+        assert f"{api_endpoint}/{image_id}/full/full/0/default.jpg" == str(img)
 
     def test_init_from_url(self):
         # well-formed
@@ -217,7 +185,7 @@ class TestIIIFImageClient:
         assert img.api_endpoint == api_endpoint
         # -info with more complex endpoint base url
         img = image.IIIFImageClient.init_from_url(VALID_URLS["info-loris"])
-        assert img.api_endpoint == "%s/loris" % api_endpoint
+        assert img.api_endpoint == f"{api_endpoint}/loris"
         # - image
         img = image.IIIFImageClient.init_from_url(VALID_URLS["simple"])
         assert isinstance(img, image.IIIFImageClient)
@@ -286,7 +254,6 @@ class TestIIIFImageClient:
         # error response
         mockresponse.status_code = 400
         img = image.IIIFImageClient.init_from_url(VALID_URLS["simple"])
-        img.image_info
         mockresponse.raise_for_status.assert_called_with()
 
     def test_image_width_height(self):
@@ -306,9 +273,9 @@ class TestIIIFImageClient:
             # percentage: convert to w,h (= 25,25)
             img.size.parse("pct:25")
             img.rotation.parse("90.0")
-            assert str(img.canonicalize()) == "%s/%s/full/25,25/90/default.jpg" % (
-                api_endpoint,
-                image_id,
+            assert (
+                str(img.canonicalize())
+                == f"{api_endpoint}/{image_id}/full/25,25/90/default.jpg"
             )
 
 
@@ -389,7 +356,7 @@ class TestImageRegion:
         assert region.as_dict()["square"] is True
         # region
         x, y, w, h = [5, 7, 100, 200]
-        region_str = "%d,%d,%d,%d" % (x, y, w, h)
+        region_str = f"{x},{y},{w},{h}"
         region.parse(region_str)
         assert str(region) == region_str  # round trip
         region_opts = region.as_dict()
@@ -400,7 +367,7 @@ class TestImageRegion:
         assert region_opts["width"] == w
         assert region_opts["height"] == h
         # percentage region
-        region_str = "pct:%d,%d,%d,%d" % (x, y, w, h)
+        region_str = f"pct:{x},{y},{w},{h}"
         region.parse(region_str)
         assert str(region) == region_str  # round trip
         region_opts = region.as_dict()
@@ -538,7 +505,7 @@ class TestImageSize:
         assert size.as_dict()["max"] is True
         # width and height
         w, h = [100, 200]
-        size_str = "%d,%d" % (w, h)
+        size_str = f"{w}, {h}"
         size.parse(size_str)
         assert str(size) == size_str  # round trip
         size_opts = size.as_dict()

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os.path
 from unittest.mock import patch
@@ -5,8 +7,7 @@ from unittest.mock import patch
 import pytest
 import requests
 
-from piffle.presentation import IIIFPresentation, IIIFException
-
+from piffle.presentation import IIIFException, IIIFPresentation
 
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 


### PR DESCRIPTION
### Summary

This PR adds dataclasses for parsing various different types of IIIF presentation/image API files.

Needed for MapReader IIIF development (https://github.com/maps-as-data/MapReader/pull/554)

### Describe your changes

- Adds `iiif_dataclasses` with methods for reading presentation2, presentation3, image2 and image3 apis.
- Adds `load_iiif.py`
- Updates pre-commit/ruff

### Checklist before assigning a reviewer (update as needed)

- [ ] Self-review code
- [ ] Ensure submission passes current tests
- [ ] Add tests
- [ ] Update relevant docs
- [ ] Update changelog

### Reviewer checklist

Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?