### PR TITLE
Adds additional pre-commit hooks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: ["main", "develop"]
   pull_request:
-    branches: [ "main", "develop" ]
+    branches: ["main", "develop"]
   schedule:
     - cron: '33 22 * * 5'
 
@@ -44,50 +44,50 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: python
-          build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+          - language: python
+            build-mode: none
+            # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+            # Use `c-cpp` to analyze code written in C, C++ or both
+            # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+            # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+            # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+            # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+            # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+            # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,16 +24,16 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,10 +1,10 @@
 name: unit tests
 
 on:
-  push: # run on all branches
+  push:  # run on all branches
   pull_request:
     branches: [develop, main]
-  schedule: # run automatically on main branch each Tuesday at 11am
+  schedule:  # run automatically on main branch each Tuesday at 11am
     - cron: "0 16 * * 2"
 
 jobs:
@@ -37,7 +37,7 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
-  # Set the color of the slack message used in the next step based on the
+      # Set the color of the slack message used in the next step based on the
       # status of the build: "danger" for failure, "good" for success,
       # "warning" for error
       - name: Set Slack message color based on build status
@@ -59,4 +59,4 @@ jobs:
           SLACK_TITLE: "Workflow `${{ github.workflow }}` (python ${{ matrix.python }}): ${{ job.status }}"
           SLACK_MESSAGE: "Run <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> on <https://github.com/${{ github.repository }}/|${{ github.repository }}@${{ github.ref }}>"
           SLACK_FOOTER: "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|View commit>"
-          MSG_MINIMAL: true # use compact slack message format
+          MSG_MINIMAL: true  # use compact slack message format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,59 @@
+# This config file specifies which pre-commit hooks to run.
+#
+# To set up, run `pre-commit install`
+# To run all hooks manually, run `pre-commit run --all-files`
 repos:
+  # Ruff Python linter and formatter (configs in pyproject.toml)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.12.5
+    rev: v0.12.7
     hooks:
-      - id: ruff
-        args: [ --fix]
-
-  - repo: https://github.com/psf/black
-    rev: 25.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
+      # Run the linter
+      - id: ruff-check
+        args: [--fix, --show-fixes]  # enable lint fixes
+      # Run the formatter
+      - id: ruff-format
+  # yamlfmt for formatting YAML files
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.17.2
     hooks:
-      - id: black
-        # Assumes that your shell's `python` command is linked to python3.6+
-        language_version: python
-
+      - id: yamlfmt
+  # Codespell for spell checking
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli
+  # Some out-of-the-box file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      # Check for files with merge conflict strings
+      - id: check-merge-conflict
+      # Verify syntax of TOML files
+      - id: check-toml
+      # Verify syntax of YAML files
+      - id: check-yaml
+        args: [--unsafe]
+      # Verifies that test files begin with test_
+      - id: name-tests-test
+        args: [--pytest-test-first]
+      # Removes trailing whitespace from all files
+      - id: trailing-whitespace
+        exclude: "docs/"
+  # Check uv.lock file is up to date
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.8.6
+    hooks:
+      - id: uv-lock
+  # Validate Github Actions schema
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.2
     hooks:
       - id: check-github-workflows
+  # Validate Github Actions workflow files
+  - repo: https://github.com/mpalmer/action-validator
+    rev: v0.8.0
+    hooks:
+      - id: action-validator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change & Version Information
 
+## 0.7.1
+
+* Adopted uv support and package src layout
+* Setup additional pre-commit hooks and adopted Ruff-based formatting
+
 ## 0.7.0
 
 *experimental* new dataclass interfaces in `piffle.iiif_dataclasses` thanks to @rwood-97
@@ -8,7 +13,7 @@
     * New `collect_annotations` method to collect annotations on a presentation
   * Now supports IIIF Presentation API and Image API version 3.
   * Adds `load_iiif_image` and `load_iiif_presentation` functions for loading IIIF into dataclasses.
-  
+
 **NOTE**: new dataclasses do not yet replace the existing default API;
 interface and package structure may change in future releases.
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ of your choice for creating python virtual environments (e.g., `mamba`, `venv`).
   It can be installed via PyPi, Homebrew, or a standalon installer.
   See `uv`'s [installation documentation](https://docs.astral.sh/uv/getting-started/installation)
   for more details.
-  
+
 - To explicitly sync the project's dependencies, including optional dependencies for
   development and testing, to your local environment run:
- 
+
   ```
   uv sync
   ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,22 @@ exclude_lines = [
 
 [tool.coverage.html]
 directory = "coverage_html_report"
+
+[tool.ruff.lint]
+# Include these rules in addition to ruff's defaults
+extend-select = [
+  "B",    # flake8-bugbear
+  "C4",   # flake8-comprehensions
+  "I",    #isort
+  "NPY",  # numpy-specific rules
+  "PERF", # perflint
+  "PTH",  # flake8-use-pathlib
+  "RUF",  # ruff-specific rules
+  "SIM",  # flake8-simplify
+  "UP",   # pyupgrade
+]
+# Can use to ignore specific rules within above selection
+ignore = []
+
+[tool.codespell]
+ignore-words-list = "pres"  # shorthand for presentation

--- a/src/piffle/iiif_dataclasses/presentation2.py
+++ b/src/piffle/iiif_dataclasses/presentation2.py
@@ -205,7 +205,6 @@ class Range2(IIIFPresentation2):
         canvases: list[Canvas2 | Any] = [],
         **kwargs,
     ):
-
         if context is None:
             log.warning("Range is missing 'context' field.")
         if id is None:

--- a/src/piffle/image.py
+++ b/src/piffle/image.py
@@ -78,7 +78,7 @@ class ImageRegion:
             return img
 
     def set_options(self, **options):
-        """Update region options.  Same parameters as initialiation."""
+        """Update region options.  Same parameters as initialization."""
         allowed_options = list(self.options.keys())
         # error if an unrecoganized option is specified
         for key in options:
@@ -178,7 +178,7 @@ class ImageRegion:
         ):
             return
 
-        # possbly an error here for every other case if self.img is not set,
+        # possibly an error here for every other case if self.img is not set,
         # since it's probably not possible to canonicalize without knowing
         # image size  (any exceptions?)
         if self.img is None:
@@ -298,7 +298,7 @@ class ImageSize:
             return img
 
     def set_options(self, **options):
-        """Update size options.  Same parameters as initialiation."""
+        """Update size options.  Same parameters as initialization."""
         allowed_options = list(self.options.keys())
         # error if an unrecoganized option is specified
         for key in options:
@@ -386,7 +386,7 @@ class ImageSize:
             # nothing to do
             return
 
-        # possbly an error here for every other case if self.img is not set,
+        # possibly an error here for every other case if self.img is not set,
         # since it's probably not possible to canonicalize without knowing
         # image size  (any exceptions?)
         if self.img is None:
@@ -475,7 +475,7 @@ class ImageRotation:
             return img
 
     def set_options(self, **options):
-        """Update size options.  Same parameters as initialiation."""
+        """Update size options.  Same parameters as initialization."""
         allowed_options = self.options.keys()
         # error if an unrecoganized option is specified
         for key in options:
@@ -588,7 +588,7 @@ class IIIFImageClient:
             self.image_options["fmt"] = fmt
 
     def get_image_id(self):
-        "Image id to be used in contructing urls"
+        "Image id to be used in constructing urls"
         return self.image_id
 
     def __str__(self):

--- a/src/piffle/presentation.py
+++ b/src/piffle/presentation.py
@@ -82,7 +82,7 @@ class IIIFPresentation(AtDict):
 
     @classmethod
     def from_url(cls, uri):
-        """Iniitialize :class:`IIIFPresentation` from a URL.
+        """Initialize :class:`IIIFPresentation` from a URL.
 
         :raises: :class:`IIIFException` if URL is not retrieved successfully,
             if the response is not JSON content, or if the JSON cannot be parsed.
@@ -110,7 +110,7 @@ class IIIFPresentation(AtDict):
 
     @classmethod
     def from_file_or_url(cls, path):
-        """Iniitialize :class:`IIIFPresentation` from a file or a url."""
+        """Initialize :class:`IIIFPresentation` from a file or a url."""
         if os.path.isfile(path):
             return cls.from_file(path)
         elif cls.is_url(path):

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -1,0 +1,6 @@
+# This is the config file for yamlfmt
+# For more details, see:
+#   https://github.com/google/yamlfmt/blob/main/docs/config-file.md
+formatter:
+  retain_line_breaks_single: true
+  pad_line_comments: 2


### PR DESCRIPTION
**Associated Issue(s):** resolves #36 

### Changes in this PR

- Adds pre-commit hooks for yamlfmt, codespell, various file checks, uv.lock check, and GitHub Actions file validation.
- Updates ruff pre-commit hook to run both linter and formatter. Adopts additional ruff rules now defined in pyproject.toml.
- Removes black pre-commit hook.
- Edits to various files to address issues raised by hooks.

### Reviewer Checklist

- [ ] Confirm that formatting changes look reasonable
