### PR TITLE
Fix path for unit tests badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python library for generating and parsing [IIIF Image API](http://iiif.io/api/im
 object-oriented, pythonic fashion.
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13308491.svg)](https://doi.org/10.5281/zenodo.13308491)
-[![unit tests](https://github.com/Princeton-CDH/piffle/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/Princeton-CDH/piffle/actions/workflows/unit_tests.yml)
+[![unit tests](https://github.com/Princeton-CDH/piffle/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/Princeton-CDH/piffle/actions/workflows/unit-tests.yml)
 [![codecov](https://codecov.io/gh/Princeton-CDH/piffle/branch/main/graph/badge.svg)](https://codecov.io/gh/Princeton-CDH/piffle)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/piffle)
 


### PR DESCRIPTION
My initial patch edit in #61 was based on `main` and switching the base for the PR resulted in a bunch of changes.  Rebasing also for some reason was not trivial; so I made a new feature branch and cherry-picked the edit over.  (Hardly worth this much effort... )
