### PR TITLE
Consolidate matrix build slack notifications

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  BASE_REF: ${{ github.base_ref }}
   # Prevent uv from including develop dependencies by default
   UV_NO_DEV: 1
   # Prevent uv run from syncing by default
@@ -55,18 +56,81 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
-      # Set the color of the slack message used in the next step based on the
-      # status of the build: "danger" for failure, "good" for success,
-      # "warning" for error
-      - name: Set Slack message color based on build status
-        if: ${{ always() }}
+      # Record per-version status so the aggregator job can build a multi-line
+      # Slack message with one line per Python version. Uses always() so a
+      # status is recorded even when pytest fails.
+      - name: Record build status for Slack summary
+        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
         env:
           JOB_STATUS: ${{ job.status }}
-        run: echo "SLACK_COLOR=$(if [ "$JOB_STATUS" == "success" ]; then echo "good"; elif [ "$JOB_STATUS" == "failure" ]; then echo "danger"; else echo "warning"; fi)" >> $GITHUB_ENV
+          PYTHON_VERSION: ${{ matrix.python }}
+        run: |
+          mkdir -p build-status
+          case "$JOB_STATUS" in
+            success)   ICON=":white_check_mark:" ;;
+            failure)   ICON=":x:" ;;
+            cancelled) ICON=":no_entry_sign:" ;;
+            *)         ICON=":warning:" ;;
+          esac
+          # Sanitize the python version for use in a filename (e.g. 3.12 -> 3-12)
+          SAFE_VERSION="${PYTHON_VERSION//./-}"
+          printf '• python %s: %s %s' "$PYTHON_VERSION" "$ICON" "$JOB_STATUS" \
+            > "build-status/${SAFE_VERSION}.txt"
+
+      - name: Upload build status artifact
+        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: build-status-${{ matrix.python }}
+          path: build-status/
+          retention-days: 1
+
+  # Aggregate matrix results and send a single Slack notification for the
+  # entire workflow run, rather than one per matrix job. The message body
+  # contains one line per Python version, similar to GitHub's own check
+  # summaries.
+  notify-slack:
+    name: Report status to Slack
+    needs: python-unit
+    runs-on: ubuntu-latest
+    # Only run on scheduled builds & pushes, since PRs automatically report to
+    # Slack. Use always() so this runs even when the test matrix fails.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    steps:
+      - name: Download per-version build statuses
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: build-status
+          pattern: build-status-*
+          merge-multiple: true
+
+      # Set the color of the slack message used in the next step based on the
+      # aggregate status of the matrix build: "danger" for failure, "good" for
+      # success, "warning" for anything else (cancelled, skipped, etc.)
+      - name: Set Slack message color based on build status
+        env:
+          BUILD_STATUS: ${{ needs.python-unit.result }}
+        run: echo "SLACK_COLOR=$(if [ "$BUILD_STATUS" == "success" ]; then echo "good"; elif [ "$BUILD_STATUS" == "failure" ]; then echo "danger"; else echo "warning"; fi)" >> $GITHUB_ENV
+
+      # Build the per-version summary block by concatenating all the artifact
+      # files (sorted by version) into a single multi-line string. Escape
+      # newlines so ENABLE_ESCAPES in the Slack action expands them.
+      - name: Build Slack message body
+        run: |
+          {
+            printf 'SLACK_MESSAGE<<EOF\n'
+            printf 'Run <https://github.com/%s/actions/runs/%s|#%s> on <https://github.com/%s/|%s@%s>\n' \
+              "${{ github.repository }}" "${{ github.run_id }}" "${{ github.run_number }}" \
+              "${{ github.repository }}" "${{ github.repository }}" "${BASE_REF}"
+            for f in $(ls build-status/*.txt 2>/dev/null | sort -V); do
+              cat "$f"
+              printf '\n'
+            done
+            printf 'EOF\n'
+          } >> "$GITHUB_ENV"
 
       # Send a message to slack to report the build status. The webhook is stored
-      # at the organization level and available to all repositories. Only run on
-      # scheduled builds & pushes, since PRs automatically report to Slack.
+      # at the organization level and available to all repositories.
       - name: Report status to Slack
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661  # v.2.4.0
         if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
@@ -74,7 +138,7 @@ jobs:
         env:
           SLACK_COLOR: ${{ env.SLACK_COLOR }}
           SLACK_WEBHOOK: ${{ secrets.ACTIONS_SLACK_WEBHOOK }}
-          SLACK_TITLE: "Workflow `${{ github.workflow }}` (python ${{ matrix.python }}): ${{ job.status }}"
-          SLACK_MESSAGE: "Run <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> on <https://github.com/${{ github.repository }}/|${{ github.repository }}@${{ github.ref }}>"
+          SLACK_TITLE: "Workflow `${{ github.workflow }}`: ${{ needs.python-unit.result }}"
+          SLACK_MESSAGE: ${{ env.SLACK_MESSAGE }}
           SLACK_FOOTER: "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|View commit>"
           MSG_MINIMAL: true  # use compact slack message format

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,7 +77,7 @@ jobs:
           esac
           # Sanitize the python version for use in a filename (e.g. 3.12 -> 3-12)
           SAFE_VERSION="${PYTHON_VERSION//./-}"
-          printf '• python %s: %s %s' "$PYTHON_VERSION" "$ICON" "$JOB_STATUS" \
+          printf '• %s python %s: %s'  "$ICON" "$PYTHON_VERSION" "$JOB_STATUS" \
             > "build-status/${SAFE_VERSION}.txt"
 
       - name: Upload build status artifact

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,7 +60,7 @@ jobs:
       # Slack message with one line per Python version. Uses always() so a
       # status is recorded even when pytest fails.
       - name: Record build status for Slack summary
-        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        if: ${{ always() }}
         env:
           JOB_STATUS: ${{ job.status }}
           PYTHON_VERSION: ${{ matrix.python }}
@@ -78,7 +78,7 @@ jobs:
             > "build-status/${SAFE_VERSION}.txt"
 
       - name: Upload build status artifact
-        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-status-${{ matrix.python }}
@@ -93,9 +93,9 @@ jobs:
     name: Report status to Slack
     needs: python-unit
     runs-on: ubuntu-latest
-    # Only run on scheduled builds & pushes, since PRs automatically report to
-    # Slack. Use always() so this runs even when the test matrix fails.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Run for every workflow trigger (PRs, pushes, scheduled). Use always() so
+    # this runs even when the test matrix fails.
+    if: ${{ always() }}
     steps:
       - name: Download per-version build statuses
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -104,24 +104,22 @@ jobs:
           pattern: build-status-*
           merge-multiple: true
 
-      # Set the color of the slack message used in the next step based on the
-      # aggregate status of the matrix build: "danger" for failure, "good" for
-      # success, "warning" for anything else (cancelled, skipped, etc.)
-      - name: Set Slack message color based on build status
+      # Assemble the per-version summary by concatenating the artifact files
+      # (sorted by version) into a multi-line string for the Slack payload.
+      # Also pick an attachment color based on the aggregate matrix result:
+      # green for success, red for failure, yellow for anything else.
+      - name: Build Slack message body
         env:
           BUILD_STATUS: ${{ needs.python-unit.result }}
-        run: echo "SLACK_COLOR=$(if [ "$BUILD_STATUS" == "success" ]; then echo "good"; elif [ "$BUILD_STATUS" == "failure" ]; then echo "danger"; else echo "warning"; fi)" >> $GITHUB_ENV
-
-      # Build the per-version summary block by concatenating all the artifact
-      # files (sorted by version) into a single multi-line string. Escape
-      # newlines so ENABLE_ESCAPES in the Slack action expands them.
-      - name: Build Slack message body
         run: |
+          case "$BUILD_STATUS" in
+            success) COLOR="#36a64f" ;;
+            failure) COLOR="#d00000" ;;
+            *)       COLOR="#dbab09" ;;
+          esac
+          echo "SLACK_COLOR=$COLOR" >> "$GITHUB_ENV"
           {
-            printf 'SLACK_MESSAGE<<EOF\n'
-            printf 'Run <https://github.com/%s/actions/runs/%s|#%s> on <https://github.com/%s/|%s@%s>\n' \
-              "${{ github.repository }}" "${{ github.run_id }}" "${{ github.run_number }}" \
-              "${{ github.repository }}" "${{ github.repository }}" "${BASE_REF}"
+            printf 'SLACK_MATRIX_LINES<<EOF\n'
             for f in $(ls build-status/*.txt 2>/dev/null | sort -V); do
               cat "$f"
               printf '\n'
@@ -129,16 +127,30 @@ jobs:
             printf 'EOF\n'
           } >> "$GITHUB_ENV"
 
-      # Send a message to slack to report the build status. The webhook is stored
-      # at the organization level and available to all repositories.
+      # Send a single message to Slack with a Block Kit layout: a header with
+      # the overall status, a context line linking to the run, and a section
+      # listing per-version results. The webhook is stored at the organization
+      # level and available to all repositories.
       - name: Report status to Slack
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661  # v.2.4.0
-        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         continue-on-error: true
-        env:
-          SLACK_COLOR: ${{ env.SLACK_COLOR }}
-          SLACK_WEBHOOK: ${{ secrets.ACTIONS_SLACK_WEBHOOK }}
-          SLACK_TITLE: "Workflow `${{ github.workflow }}`: ${{ needs.python-unit.result }}"
-          SLACK_MESSAGE: ${{ env.SLACK_MESSAGE }}
-          SLACK_FOOTER: "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|View commit>"
-          MSG_MINIMAL: true  # use compact slack message format
+        with:
+          webhook: ${{ secrets.ACTIONS_SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            attachments:
+              - color: "${{ env.SLACK_COLOR }}"
+                blocks:
+                  - type: "header"
+                    text:
+                      type: "plain_text"
+                      text: "unit tests: ${{ needs.python-unit.result }}"
+                  - type: "section"
+                    text:
+                      type: "mrkdwn"
+                      text: "Run <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> on `${{ github.ref_name }}` (<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|`${{ github.sha }}`>)"
+                  - type: "section"
+                    text:
+                      type: "mrkdwn"
+                      text: |
+                        ${{ env.SLACK_MATRIX_LINES }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,11 @@ env:
   UV_NO_DEV: 1
   # Prevent uv run from syncing by default
   UV_NO_SYNC: 1
+  # Icon lookup for per-version Slack summary lines
+  ICON_SUCCESS: ":white_check_mark:"
+  ICON_FAILURE: ":x:"
+  ICON_CANCELLED: ":no_entry_sign:"
+  ICON_OTHER: ":warning:"
 
 jobs:
   python-unit:
@@ -65,10 +70,10 @@ jobs:
         run: |
           mkdir -p build-status
           case "$JOB_STATUS" in
-            success)   ICON=":white_check_mark:" ;;
-            failure)   ICON=":x:" ;;
-            cancelled) ICON=":no_entry_sign:" ;;
-            *)         ICON=":warning:" ;;
+            success)   ICON="$ICON_SUCCESS" ;;
+            failure)   ICON="$ICON_FAILURE" ;;
+            cancelled) ICON="$ICON_CANCELLED" ;;
+            *)         ICON="$ICON_OTHER" ;;
           esac
           # Sanitize the python version for use in a filename (e.g. 3.12 -> 3-12)
           SAFE_VERSION="${PYTHON_VERSION//./-}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BASE_REF: ${{ github.base_ref }}
   # Prevent uv from including develop dependencies by default
   UV_NO_DEV: 1
   # Prevent uv run from syncing by default
@@ -56,9 +55,8 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
-      # Record per-version status so the aggregator job can build a multi-line
-      # Slack message with one line per Python version. Uses always() so a
-      # status is recorded even when pytest fails.
+      # Record per-version status for the aggregator. Uses always() so status
+      # is captured even when pytest fails.
       - name: Record build status for Slack summary
         if: ${{ always() }}
         env:
@@ -85,10 +83,8 @@ jobs:
           path: build-status/
           retention-days: 1
 
-  # Aggregate matrix results and send a single Slack notification for the
-  # entire workflow run, rather than one per matrix job. The message body
-  # contains one line per Python version, similar to GitHub's own check
-  # summaries.
+  # Aggregate results into a single Slack message with one line per Python
+  # version, rather than one per matrix job.
   notify-slack:
     name: Report status to Slack
     needs: python-unit
@@ -104,10 +100,8 @@ jobs:
           pattern: build-status-*
           merge-multiple: true
 
-      # Assemble the per-version summary by concatenating the artifact files
-      # (sorted by version) into a multi-line string for the Slack payload.
-      # Also pick an attachment color based on the aggregate matrix result:
-      # green for success, red for failure, yellow for anything else.
+      # Concatenate artifact files (sorted by version) into a multi-line string
+      # and pick attachment color based on aggregate result.
       - name: Build Slack message body
         env:
           BUILD_STATUS: ${{ needs.python-unit.result }}
@@ -127,10 +121,8 @@ jobs:
             printf 'EOF\n'
           } >> "$GITHUB_ENV"
 
-      # Send a single message to Slack with a Block Kit layout: a header with
-      # the overall status, a context line linking to the run, and a section
-      # listing per-version results. The webhook is stored at the organization
-      # level and available to all repositories.
+      # Send a single Slack message with a Block Kit layout: header (overall
+      # status), context (run + commit link), and section (per-version lines).
       - name: Report status to Slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         continue-on-error: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -105,8 +105,10 @@ jobs:
           pattern: build-status-*
           merge-multiple: true
 
-      # Concatenate artifact files (sorted by version) into a multi-line string
-      # and pick attachment color based on aggregate result.
+      # Concatenate artifact files (sorted by version) into a multi-line string,
+      # pick attachment color based on aggregate result, and build the complete
+      # Slack payload as JSON (avoiding YAML indentation issues with the
+      # multi-line substitution).
       - name: Build Slack message body
         env:
           BUILD_STATUS: ${{ needs.python-unit.result }}
@@ -116,38 +118,34 @@ jobs:
             failure) COLOR="#d00000" ;;
             *)       COLOR="#dbab09" ;;
           esac
-          echo "SLACK_COLOR=$COLOR" >> "$GITHUB_ENV"
-          {
-            printf 'SLACK_MATRIX_LINES<<EOF\n'
-            for f in $(ls build-status/*.txt 2>/dev/null | sort -V); do
-              cat "$f"
-              printf '\n'
-            done
-            printf 'EOF\n'
-          } >> "$GITHUB_ENV"
 
-      # Send a single Slack message with a Block Kit layout: header (overall
-      # status), context (run + commit link), and section (per-version lines).
+          MATRIX_LINES=""
+          for f in $(ls build-status/*.txt 2>/dev/null | sort -V); do
+            MATRIX_LINES="${MATRIX_LINES}$(cat "$f")"$'\n'
+          done
+
+          jq -n \
+            --arg color "$COLOR" \
+            --arg status "unit tests: ${{ needs.python-unit.result }}" \
+            --arg run_url "Run <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> on \`${GITHUB_REF_NAME}\` (<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|\`${{ github.sha }}\`>)" \
+            --arg matrix "$MATRIX_LINES" \
+            '{
+              "attachments": [
+                {
+                  "color": $color,
+                  "blocks": [
+                    {"type": "header", "text": {"type": "plain_text", "text": $status}},
+                    {"type": "section", "text": {"type": "mrkdwn", "text": $run_url}},
+                    {"type": "section", "text": {"type": "mrkdwn", "text": $matrix}}
+                  ]
+                }
+              ]
+            }' > slack-payload.json
+
       - name: Report status to Slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         continue-on-error: true
         with:
           webhook: ${{ secrets.ACTIONS_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook
-          payload: |
-            attachments:
-              - color: "${{ env.SLACK_COLOR }}"
-                blocks:
-                  - type: "header"
-                    text:
-                      type: "plain_text"
-                      text: "unit tests: ${{ needs.python-unit.result }}"
-                  - type: "section"
-                    text:
-                      type: "mrkdwn"
-                      text: "Run <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> on `${{ github.ref_name }}` (<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|`${{ github.sha }}`>)"
-                  - type: "section"
-                    text:
-                      type: "mrkdwn"
-                      text: |
-                        ${{ env.SLACK_MATRIX_LINES }}
+          payload-file-path: slack-payload.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.10.0
 
+#### GitHub Actions
+
+- Update unit test GitHub Action to send one aggregated Slack notification
+
 ## 0.9.0
 
 ### Development


### PR DESCRIPTION
**Associated Issue(s):** N/A

### Changes in this PR

- Split out slack notification task so it gathers all unit test status and reports once instead of per build
- Each build now uploads a one-line text file with the status for aggregation
- Switched to slack webhook instead of the github action we were using; there's an official slack github action, but it sounds like the set up is more involved, webhok works with our existing setup

### Notes

- I got tired of the verbosity of the matrix build status in our slack maintenance channel and thought this was probably amenable to agentic ai.  Used Claude opus-4.7 for most of it, reviewed and refactored with glm-5.1.
- We might want to tweak notification, hash is verbose and it's not as obvious as it should be which report is the push and which is the merge. (Also we might consider disabling the PR report, since depending on slack notification setup it could be redundant.)

- 🤖 Assisted-by: 
   - Claude:opus-4.7 opencode
   - BigPicklee:glm-5.1 opencode
   - zizmor

### Reviewer Checklist

- [ ] Review the changes
- [ ] Check the notification in slack - any small adjustments to make?
- [ ] Should we do any other testing? make one version fail / all versions fail?
